### PR TITLE
edit a material by doubleclicking on the property

### DIFF
--- a/app/scripts/src/lib/render_project.ts
+++ b/app/scripts/src/lib/render_project.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { Project } from './Project';
-import { delayEvent, desanitize, sanitize } from './utils';
+import { delayEvent, desanitize, isInvalid, sanitize } from './utils';
 import { throwFatalErr, throwErr } from './errors';
 // @ts-expect-error
 import projectTemplate from '../../../project_template.html';
@@ -138,7 +138,13 @@ export function renderMatCol(project: Project): void {
         return async (event: KeyboardEvent) => {
             if (event.code !== 'Enter') return;
             const eventTarget = event.target as HTMLInputElement;
+            eventTarget.classList.remove('invalid');
             const newValue = eventTarget.value;
+            if (!newValue || isInvalid(newValue)) {
+                eventTarget.classList.add('invalid');
+                throwErr('Eingabefehler', 'Feld darf nicht leer sein und darf keine , oder " enthalten.');
+                return;
+            }
             const projectStr = sessionStorage.getItem('CURRENT_PROJ');
             const filePath = sessionStorage.getItem('CURRENT_PROJ_LOC');
             if (!projectStr || !filePath) {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -41,6 +41,10 @@ body {
     margin: auto;
 }
 
+input.invalid {
+    border: 1px solid var(--secundary-color);
+}
+
 .center {
     text-align: center;
     padding: auto;

--- a/app/styles/new_object.css
+++ b/app/styles/new_object.css
@@ -18,10 +18,6 @@ input[type="number"] {
     text-align: right;
 }
 
-input.invalid {
-    border: 1px solid var(--secundary-color);
-}
-
 textarea {
     width: calc(100% - 40px);
     margin: 7px 20px;


### PR DESCRIPTION
This PR closes #30 

To edit a material after it has been added, double click on one of the properties. This turns the contents of that table cell into an input field, where changes can be made and accepted by pressing `Enter`.  The table is then re-rendered.