### PR TITLE
Fix bug when editing date

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
+dist/
 app/scripts/dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
         "indent": ["error", 4, { "SwitchCase": 1 }],
         "key-spacing": ["warn", { "mode": "strict" }],
         "keyword-spacing": "error",
-        "line-comment-position": ["warn", { "position": "beside" }],
+        "line-comment-position": "off",
         "max-depth": ["warn", 3],
         "max-len": ["warn", { "code": 130, "ignoreComments": true }],
         "max-lines": ["warn", 400],
@@ -76,7 +76,13 @@
         "prefer-promise-reject-errors": "error",
         "prefer-template": "warn",
         "quotes": ["error", "single"],
-        "require-jsdoc": "warn",
+        "require-jsdoc": ["warn", {
+            "require": {
+                "FunctionDeclaration": true,
+                "MethodDefinition": true,
+                "ClassDeclaration": true
+            }
+        }],
         "sort-imports": "warn",
         "valid-jsdoc": "off",
         "yoda": ["warn", "never"],

--- a/app/scripts/src/lib/Project.ts
+++ b/app/scripts/src/lib/Project.ts
@@ -73,6 +73,10 @@ interface SaveProjectOptions {
     otherCsv?: string;
 }
 
+/**
+ * Class representing a project object. Combines functionality to parse and
+ * save the project to disk in csv format.
+ */
 export class Project {
     private static storageKeys = {
         project: 'CURRENT_PROJ',
@@ -88,6 +92,7 @@ export class Project {
     public materials: Material[];
     public workers: Worker[];
 
+    /** Constructs a new `Project` instance */
     public constructor(params: ProjectConstructorParams) {
         this.id = params.shouldGenId ? genId() : '';
         this.name = params.name;

--- a/app/scripts/src/lib/render_project.ts
+++ b/app/scripts/src/lib/render_project.ts
@@ -113,11 +113,7 @@ function setupHeaderEditInputs(elementType: HeaderDisplayType) {
                 inputEl.value = project.date;
                 break;
         }
-        if (elementType === HeaderDisplayType.DATE) {
-            inputEl.addEventListener('keypress', editInputHandlerForHeader(elementType, project, filePath));
-        } else {
-            inputEl.addEventListener('change', editInputHandlerForHeader(elementType, project, filePath));
-        }
+        inputEl.addEventListener('keypress', editInputHandlerForHeader(elementType, project, filePath));
         inputEl.addEventListener('blur', () => {
             eventTarget.textContent = oldValue;
         });
@@ -134,8 +130,8 @@ function setupHeaderEditInputs(elementType: HeaderDisplayType) {
  * be out of sync by then. Calls a re-render of the header at the end.
  */
 function editInputHandlerForHeader(elementType: HeaderDisplayType, project: Project, projectFilePath: string) {
-    return async (event: Event | KeyboardEvent) => {
-        if (Events.isKeyboardEvent(event) && event.code !== 'Enter') return;
+    return async (event: KeyboardEvent) => {
+        if (event.code !== 'Enter') return;
         const inputEl = event.target as HTMLInputElement;
         inputEl.classList.remove('invalid');
         const newVal = inputEl.value;

--- a/app/scripts/src/lib/utils.ts
+++ b/app/scripts/src/lib/utils.ts
@@ -1,33 +1,44 @@
-/**
- * Delays the firing of a event handler. **Note**: If the handler gets called
- * multiple times _within_ the delay time period, only the _last one_ will
- * actually get executed.
- */
-export function debounceEvent<T extends unknown[]>(ms: number, callback: (...args: T) => void): (...args: T) => void {
-    let timer = 0;
-    return (...args: T) => {
-        clearTimeout(timer);
-        timer = window.setTimeout(() => callback(...args), ms);
-    };
+/** Namespace for utility methods regarding string validation and sanitization. */
+export abstract class Validation {
+    /**
+     * Replaces commas and double quotes in a string with placeholders so it can
+     * savely be stored in CSV format.
+     */
+    public static sanitize(input: string): string {
+        return input.replace(/,/g, '{{c}}').replace(/"/g, '{{dq}}');
+    }
+
+    /**
+     * Replaces the placeholders for commas and double quotes with their
+     * correct values.
+     */
+    public static desanitize(input: string): string {
+        return input.replace(/{{c}}/g, ',').replace(/{{dq}}/g, '"');
+    }
+
+    /** Checks if a string contains `"` or `,`. If so, returns `true`. */
+    public static isInvalid(input: string): boolean {
+        return (/,|"/g).test(input);
+    }
 }
 
-/**
- * Replaces commas and double quotes in a string with placeholders so it can
- * savely be stored in CSV format.
- */
-export function sanitize(input: string): string {
-    return input.replace(/,/g, '{{c}}').replace(/"/g, '{{dq}}');
-}
+/** Namespace for utility methods regarding Events */
+export abstract class Events {
+    /** Checks if a given variable is of type `KeyboardEvent`. */
+    public static isKeyboardEvent(event: unknown): event is KeyboardEvent {
+        return event instanceof KeyboardEvent;
+    }
 
-/**
- * Replaces the placeholders for commas and double quotes with their
- * correct values.
- */
-export function desanitize(input: string): string {
-    return input.replace(/{{c}}/g, ',').replace(/{{dq}}/g, '"');
-}
-
-/** Checks if a string contains `"` or `,`. If so, returns `true`. */
-export function isInvalid(input: string): boolean {
-    return (/,|"/g).test(input);
+    /**
+     * Delays the firing of a event handler. **Note**: If the handler gets called
+     * multiple times _within_ the delay time period, only the _last one_ will
+     * actually get executed.
+     */
+    public static debounce<T extends unknown[]>(ms: number, callback: (...args: T) => void): (...args: T) => void {
+        let timer = 0;
+        return (...args: T) => {
+            window.clearTimeout(timer);
+            timer = window.setTimeout(() => callback(...args), ms);
+        };
+    }
 }

--- a/app/scripts/src/lib/utils.ts
+++ b/app/scripts/src/lib/utils.ts
@@ -24,11 +24,6 @@ export abstract class Validation {
 
 /** Namespace for utility methods regarding Events */
 export abstract class Events {
-    /** Checks if a given variable is of type `KeyboardEvent`. */
-    public static isKeyboardEvent(event: unknown): event is KeyboardEvent {
-        return event instanceof KeyboardEvent;
-    }
-
     /**
      * Delays the firing of a event handler. **Note**: If the handler gets called
      * multiple times _within_ the delay time period, only the _last one_ will

--- a/app/scripts/src/new_material.ts
+++ b/app/scripts/src/new_material.ts
@@ -1,6 +1,6 @@
 import type { Material } from './lib/Project';
 import type { MessageData } from '.';
-import { isInvalid } from './lib/utils';
+import { Validation } from './lib/utils';
 import { throwErr } from './lib/errors';
 
 document.getElementById('mat-name-input')?.focus();
@@ -15,12 +15,12 @@ document.getElementById('submit-btn')?.addEventListener('click', () => {
 
     {
         let exitDueToError = false;
-        if (nameInput.value.length === 0 || isInvalid(nameInput.value)) {
+        if (nameInput.value.length === 0 || Validation.isInvalid(nameInput.value)) {
             nameInput.classList.add('invalid');
             exitDueToError = true;
         }
 
-        if (receiptIdInput.value.length === 0 || isInvalid(receiptIdInput.value)) {
+        if (receiptIdInput.value.length === 0 || Validation.isInvalid(receiptIdInput.value)) {
             receiptIdInput.classList.add('invalid');
             exitDueToError = true;
         }

--- a/app/scripts/src/new_project.ts
+++ b/app/scripts/src/new_project.ts
@@ -1,7 +1,7 @@
 import * as remote from '@electron/remote';
-import { isInvalid, sanitize } from './lib/utils';
 import type { MessageData } from '.';
 import { Project } from './lib/Project';
+import { Validation } from './lib/utils';
 import { throwErr } from './lib/errors';
 
 document.getElementById('submit-btn')?.addEventListener('click', async () => {
@@ -16,12 +16,12 @@ document.getElementById('submit-btn')?.addEventListener('click', async () => {
     /* input validation */
     {
         let exitDueToError = false;
-        if (nameInput.value.length === 0 || isInvalid(nameInput.value)) {
+        if (nameInput.value.length === 0 || Validation.isInvalid(nameInput.value)) {
             nameInput.classList.add('invalid');
             exitDueToError = true;
         }
 
-        if (placeInput.value.length === 0 || isInvalid(placeInput.value)) {
+        if (placeInput.value.length === 0 || Validation.isInvalid(placeInput.value)) {
             placeInput.classList.add('invalid');
             exitDueToError = true;
         }
@@ -55,7 +55,7 @@ document.getElementById('submit-btn')?.addEventListener('click', async () => {
         name: nameInput.value,
         date: dateInput.value,
         place: placeInput.value,
-        description: sanitize(notesInput.value),
+        description: Validation.sanitize(notesInput.value),
         brutto: 0,
         shouldGenId: true
     });

--- a/app/scripts/src/new_worker_type.ts
+++ b/app/scripts/src/new_worker_type.ts
@@ -1,6 +1,6 @@
 import type { MessageData } from '.';
+import { Validation } from './lib/utils';
 import type { Worker } from './lib/Project';
-import { isInvalid } from './lib/utils';
 import { throwErr } from './lib/errors';
 
 document.getElementById('type-name-input')?.focus();
@@ -15,7 +15,7 @@ document.getElementById('submit-btn')?.addEventListener('click', () => {
 
     {
         let exitDueToError = false;
-        if (typeInput.value.length === 0 || isInvalid(typeInput.value)) {
+        if (typeInput.value.length === 0 || Validation.isInvalid(typeInput.value)) {
             typeInput.classList.add('invalid');
             exitDueToError = true;
         }


### PR DESCRIPTION
fix #59 
Refactor utility methods into abstract classes. Furthermore, for edit inputs on project properties, use the `keypress` event. It's not the best user experience, but the best possible with the `input[type="date"]` bug, where the `input` and `change` events are essentially the same.